### PR TITLE
Add Invenio-Community-Themes-TUW package

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,18 +38,18 @@ Inspired by [awesome-python](https://github.com/vinta/awesome-python).
 * [invenio-pidstore-extra](https://github.com/ulbmuenster/invenio-pidstore-extra) - Adds support for URN minting for german and swiss libraries via API of the Deutsche Nationalbibliothek.
 
 ### Configuration
-* [invenio-config-tuw](https://gitlab.tuwien.ac.at/fairdata/invenio-config-tuw) - Customized workflows and baseline configuration for [TU Wien Research Data](https://researchdata.tuwien.ac.at/).
+* [invenio-config-tuw](https://gitlab.tuwien.ac.at/crdm/invenio-config-tuw) - Customized workflows and baseline configuration for [TU Wien Research Data](https://researchdata.tuwien.ac.at/).
 * [invenio-config-tugraz](https://github.com/tu-graz-library/invenio-config-tugraz) - Override configuration from different Invenio modules to meet [TU Graz](https://www.tugraz.at/home) requirements.
 
 ### Theming
-* [invenio-theme-tuw](https://gitlab.tuwien.ac.at/fairdata/invenio-theme-tuw) - Corporate design for [TU Wien](https://www.tuwien.at/), used in [TU Wien Research Data](https://researchdata.tuwien.ac.at/).
+* [invenio-theme-tuw](https://gitlab.tuwien.ac.at/crdm/invenio-theme-tuw) - Corporate design for [TU Wien](https://www.tuwien.at/), used in [TU Wien Research Data](https://researchdata.tuwien.ac.at/).
 * [invenio-theme-tugraz](https://github.com/tu-graz-library/invenio-theme-tugraz) - [TU Graz](https://github.com/tu-graz-library/invenio-theme-tugraz) standard theme for InvenioRDM.
 
 ### Analytics/Statistics
 * [invenio-analytics-importer](https://github.com/galter-dmt/invenio-analytics-importer) - CLI to retrieve and ingest (Matomo) analytics into your InvenioRDM instance
 
 ### General
-* [invenio-utilities-tuw](https://gitlab.tuwien.ac.at/fairdata/invenio-utilities-tuw) - Extra CLI utilities for InvenioRDM, of varying quality and usefulness.
+* [invenio-utilities-tuw](https://gitlab.tuwien.ac.at/crdm/invenio-utilities-tuw) - Extra CLI utilities for InvenioRDM, of varying quality and usefulness.
 
 ## For developers
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Inspired by [awesome-python](https://github.com/vinta/awesome-python).
 ### Theming
 * [invenio-theme-tuw](https://gitlab.tuwien.ac.at/crdm/invenio-theme-tuw) - Corporate design for [TU Wien](https://www.tuwien.at/), used in [TU Wien Research Data](https://researchdata.tuwien.ac.at/).
 * [invenio-theme-tugraz](https://github.com/tu-graz-library/invenio-theme-tugraz) - [TU Graz](https://github.com/tu-graz-library/invenio-theme-tugraz) standard theme for InvenioRDM.
+* [invenio-community-themes-tuw](https://gitlab.tuwien.ac.at/crdm/invenio-community-themes-tuw) - Sources for the **themed communities** at TU Wien, showcasing how the feature can be used for more involved customizations.
 
 ### Analytics/Statistics
 * [invenio-analytics-importer](https://github.com/galter-dmt/invenio-analytics-importer) - CLI to retrieve and ingest (Matomo) analytics into your InvenioRDM instance


### PR DESCRIPTION
Add the [`Invenio-Community-Themes-TUW`](https://gitlab.tuwien.ac.at/crdm/invenio-community-themes-tuw) package, which implements the themed communities in TU Wien Research Data.
This can be used as an example of how to implement themed communities that require more customizations than are outlined in the InvenioRDM docs.